### PR TITLE
Make dark mode responsive via CSS

### DIFF
--- a/docs/_data/data.yml
+++ b/docs/_data/data.yml
@@ -1,6 +1,5 @@
 name: Evan Simkowitz
 pronouns: he/him
-support_dark_mode: true
 
 # Sidebar
 contact:

--- a/docs/_includes/scripts.html
+++ b/docs/_includes/scripts.html
@@ -1,7 +1,4 @@
 <script src="https://cdn.jsdelivr.net/npm/feather-icons/dist/feather.min.js"></script>
-{% if site.data.data.support_dark_mode%}
-  <script src="{{'/assets/javascript/toggleDark.js' | absolute_url}}"></script>
-{% endif %}
 <script>
   feather.replace()
 </script>

--- a/docs/_sass/includes/footer.scss
+++ b/docs/_sass/includes/footer.scss
@@ -4,10 +4,10 @@
 
         a:link, a:visited {
             text-decoration: none;
-            color: #03619C
+            color: var(--fg-color-link)
         }
         a:hover {
-            color: #03619cc5
+            color: var(--fg-color-link-hover)
         }
     }
 }

--- a/docs/_sass/skins/blue.scss
+++ b/docs/_sass/skins/blue.scss
@@ -5,14 +5,19 @@
     --fg-color-dark: #023b5b;
     --fg-color-body: #5e6369;
     --fg-color-title-sm: #688293;
-
+    --fg-color-link: #00629b;
+    --fg-color-link-hover: #00629bc7;
 }
 
-[data-theme='dark'] {
-    --bg-color: #28343b;
-    --bg-color-cv: #1b262c;
-    --fg-color: #3282b8;
-    --fg-color-dark: #3282b8;
-    --fg-color-body: rgba(187,225,250,0.75);
-    --fg-color-title-sm: #688293;
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-color: #28343b;
+        --bg-color-cv: #1b262c;
+        --fg-color: #3282b8;
+        --fg-color-dark: #3282b8;
+        --fg-color-body: rgba(187,225,250,0.75);
+        --fg-color-title-sm: #688293;
+        --fg-color-link: #3282b8;
+        --fg-color-link-hover: #3282b8ca;
+    }
 }

--- a/docs/assets/javascript/toggleDark.js
+++ b/docs/assets/javascript/toggleDark.js
@@ -1,3 +1,0 @@
-window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-    document.documentElement.setAttribute('data-theme', event.matches ? 'dark' : 'light');
-});


### PR DESCRIPTION
Remove ability to decide whether to have dark mode included. Instead, use the @media css feature to set it automatically based on browser preferences.