### PR TITLE
Bump Pages actions to Node 24 majors, add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # The Jekyll build now runs from docs/Gemfile in the Pages workflow, so gem
+  # updates here affect the deployed site rather than just local previews.
+  - package-ecosystem: bundler
+    directory: /docs
+    schedule:
+      interval: weekly
+    # Let a release settle before proposing it.
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
           bundler-cache: true
           working-directory: docs
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
       # Built with the repo's own Gemfile rather than actions/jekyll-build-pages,
       # which uses GitHub's pinned github-pages gem set (capped at Ruby < 4.0 and
@@ -42,7 +42,7 @@ jobs:
           JEKYLL_ENV: production
         run: bundle exec jekyll build --destination ./_site
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_site
 
@@ -54,4 +54,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Follow-up to #39, which migrated the site to a GitHub Actions build.

## Node 24 deprecation warning

The first Actions deploy succeeded but warned:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/configure-pages@v5`, `actions/upload-artifact@ea165f8d...`

Bumping the three Pages actions to majors that declare `node24` upstream:

| Action | Was | Now |
| --- | --- | --- |
| `actions/configure-pages` | v5 | **v6** |
| `actions/upload-pages-artifact` | v4 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

Note the `upload-artifact` in the warning was never in our workflow directly — `upload-pages-artifact` is a composite action that calls it at a pinned SHA. v5 bumps that inner pin to `upload-artifact@v7` (`node24`), clearing the transitive half of the warning.

I verified each new major actually declares `runs.using: node24` rather than assuming the bump would help. Release notes for all three show runtime and dependency updates only — no input or output changes, so the `path:` input is unaffected.

## Dependabot config

Adds `.github/dependabot.yml`, so this class of drift doesn't recur:

- **`github-actions`** at `/` — Dependabot scans `.github/workflows/` relative to the repo root
- **`bundler`** at `/docs` — now that Pages builds from our Gemfile, gem updates affect the deployed site rather than only local previews

Both use a 7-day cooldown (`cooldown.default-days`) so a release settles before Dependabot proposes it — worth having where a bad bump breaks the deploy.

## Verification

The warning was informational, not a failure — the previous deploy succeeded and the live site is correct. Confirmed post-merge of #39:

- `robots.txt` retains its newline (`0a`), so the `Disallow` directive still parses
- `index.html` is minified in production (0 HTML comments)
- CSS returns 200; Pages reports `build_type: workflow`, `status: built`

Both YAML files parse. The real check is the deploy run on merge.